### PR TITLE
Improve workflows: reusable ACR build + consolidation

### DIFF
--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Ensure namespace exists and set as current
         run: |
           kubectl create namespace shop --dry-run=client -o yaml | kubectl apply -f -
-          # Make 'shop' the default namespace for all following kubectl commands
           kubectl config set-context --current --namespace=shop
 
       - name: Deploy Backend Infrastructure (Namespace, ConfigMaps, Secrets, Databases)
@@ -89,28 +88,39 @@ jobs:
           echo "PROD_SVC=$PROD_SVC" >> $GITHUB_ENV
           echo "ORDER_SVC=$ORDER_SVC" >> $GITHUB_ENV
 
-      - name: Wait for Backend LoadBalancer IPs
+      - name: Wait for Backend LoadBalancer IPs (robust)
         run: |
-          echo "Waiting for LoadBalancer IPs to be assigned (up to 5 minutes)..."
+          echo "Waiting for LoadBalancer endpoints (up to 12 minutes)..."
           PRODUCT_IP=""
           ORDER_IP=""
 
-          for i in $(seq 1 60); do
-            echo "Attempt $i/60 to get IPs..."
-            PRODUCT_IP=$(kubectl get service "$PROD_SVC" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
-            ORDER_IP=$(kubectl get service "$ORDER_SVC" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+          # Helper to read IP or hostname
+          get_lb_endpoint () {
+            local svc="$1"
+            local val
+            val=$(kubectl get svc "$svc" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+            if [ -z "$val" ]; then
+              val=$(kubectl get svc "$svc" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
+            fi
+            echo "$val"
+          }
 
+          # Poll up to 140 times * 5s = ~11m40s
+          for i in $(seq 1 140); do
+            echo "Attempt $i/140 ..."
+            PRODUCT_IP=$(get_lb_endpoint "$PROD_SVC")
+            ORDER_IP=$(get_lb_endpoint "$ORDER_SVC")
+            printf "  %s => '%s'\n" "$PROD_SVC"  "${PRODUCT_IP:-<pending>}"
+            printf "  %s => '%s'\n" "$ORDER_SVC" "${ORDER_IP:-<pending>}"
             if [[ -n "$PRODUCT_IP" && -n "$ORDER_IP" ]]; then
-              echo "All backend LoadBalancer IPs assigned!"
-              echo "Product Service ($PROD_SVC) IP: $PRODUCT_IP"
-              echo "Order Service   ($ORDER_SVC) IP: $ORDER_IP"
+              echo "LoadBalancer endpoints are ready."
               break
             fi
             sleep 5
           done
 
           if [[ -z "$PRODUCT_IP" || -z "$ORDER_IP" ]]; then
-            echo "Error: One or more LoadBalancer IPs not assigned after timeout."
+            echo "Error: One or more LoadBalancer endpoints not ready after timeout."
             echo "Current services in 'shop':"
             kubectl get svc -n shop -o wide || true
             exit 1
@@ -118,6 +128,8 @@ jobs:
 
           echo "PRODUCT_IP=$PRODUCT_IP" >> $GITHUB_ENV
           echo "ORDER_IP=$ORDER_IP" >> $GITHUB_ENV
+          echo "Resolved Product endpoint: $PRODUCT_IP"
+          echo "Resolved Order endpoint:   $ORDER_IP"
 
       - name: Capture Product Service IP for Workflow Output
         id: get_product_ip

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -6,21 +6,21 @@ on:
       aks_cluster_name:
         description: 'Name of the AKS Cluster to deploy to'
         required: true
-        default: '<aks_cluster_name>'
+        default: 'aks-week08'
       aks_resource_group:
         description: 'Resource Group of the AKS Cluster'
         required: true
-        default: '<resource_group_name>'
+        default: 'rg-week08'
       aks_acr_name:
         description: 'Name of ACR'
         required: true
-        default: '<acr_name>'
+        default: 'acrweek0820618'
 
 jobs:
   deploy_backend:
     runs-on: ubuntu-latest
     environment: Production
-    
+
     outputs:
       PRODUCT_API_IP: ${{ steps.get_product_ip.outputs.external_ip }}
       ORDER_API_IP: ${{ steps.get_order_ip.outputs.external_ip }}
@@ -37,11 +37,22 @@ jobs:
 
       - name: Set Kubernetes context (get AKS credentials)
         run: |
-          az aks get-credentials --resource-group ${{ github.event.inputs.aks_resource_group }} --name ${{ github.event.inputs.aks_cluster_name }} --overwrite-existing
+          az aks get-credentials \
+            --resource-group ${{ github.event.inputs.aks_resource_group }} \
+            --name ${{ github.event.inputs.aks_cluster_name }} \
+            --overwrite-existing
 
-      - name: Attach ACR
+      # We already granted AcrPull to the kubelet identity; skip attach-acr to avoid RBAC errors
+      - name: Verify AcrPull role exists (non-blocking)
         run: |
-          az aks update --name ${{ github.event.inputs.aks_cluster_name }} --resource-group ${{ github.event.inputs.aks_resource_group }} --attach-acr ${{ github.event.inputs.aks_acr_name }}
+          ACR_ID=$(az acr show -n ${{ github.event.inputs.aks_acr_name }} --query id -o tsv)
+          PRINCIPAL_ID=$(az aks show -g ${{ github.event.inputs.aks_resource_group }} -n ${{ github.event.inputs.aks_cluster_name }} --query identityProfile.kubeletidentity.objectId -o tsv)
+          echo "Listing role assignments for kubelet identity on ACR scope (for your records):"
+          az role assignment list --assignee-object-id "$PRINCIPAL_ID" --scope "$ACR_ID" -o table || true
+
+      - name: Ensure namespace exists
+        run: |
+          kubectl create namespace shop --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Deploy Backend Infrastructure (Namespace, ConfigMaps, Secrets, Databases)
         run: |
@@ -58,17 +69,17 @@ jobs:
           cd k8s/
           kubectl apply -f product-service.yaml
           kubectl apply -f order-service.yaml
-      
+
       - name: Wait for Backend LoadBalancer IPs
         run: |
           echo "Waiting for Product, Order LoadBalancer IPs to be assigned (up to 5 minutes)..."
           PRODUCT_IP=""
           ORDER_IP=""
-          
+
           for i in $(seq 1 60); do
             echo "Attempt $i/60 to get IPs..."
-            PRODUCT_IP=$(kubectl get service product-service-w08e1 -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-            ORDER_IP=$(kubectl get service order-service-w08e1 -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+            PRODUCT_IP=$(kubectl get service product-service -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
+            ORDER_IP=$(kubectl get service order-service -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
 
             if [[ -n "$PRODUCT_IP" && -n "$ORDER_IP" ]]; then
               echo "All backend LoadBalancer IPs assigned!"
@@ -76,23 +87,21 @@ jobs:
               echo "Order Service IP: $ORDER_IP"
               break
             fi
-            sleep 5 # Wait 5 seconds before next attempt
+            sleep 5
           done
-          
+
           if [[ -z "$PRODUCT_IP" || -z "$ORDER_IP" ]]; then
             echo "Error: One or more LoadBalancer IPs not assigned after timeout."
-            exit 1 # Fail the job if IPs are not obtained
+            exit 1
           fi
-          
-          # These are environment variables for subsequent steps in the *same job*
-          # And used to set the job outputs
+
           echo "PRODUCT_IP=$PRODUCT_IP" >> $GITHUB_ENV
           echo "ORDER_IP=$ORDER_IP" >> $GITHUB_ENV
 
       - name: Capture Product Service IP for Workflow Output
         id: get_product_ip
         run: echo "external_ip=${{ env.PRODUCT_IP }}" >> $GITHUB_OUTPUT
-      
+
       - name: Capture Order Service IP for Workflow Output
         id: get_order_ip
         run: echo "external_ip=${{ env.ORDER_IP }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -42,49 +42,68 @@ jobs:
             --name ${{ github.event.inputs.aks_cluster_name }} \
             --overwrite-existing
 
-      # We already granted AcrPull to the kubelet identity; skip attach-acr to avoid RBAC errors
+      # We already granted AcrPull; just log the assignment for record-keeping
       - name: Verify AcrPull role exists (non-blocking)
         run: |
           ACR_ID=$(az acr show -n ${{ github.event.inputs.aks_acr_name }} --query id -o tsv)
           PRINCIPAL_ID=$(az aks show -g ${{ github.event.inputs.aks_resource_group }} -n ${{ github.event.inputs.aks_cluster_name }} --query identityProfile.kubeletidentity.objectId -o tsv)
-          echo "Listing role assignments for kubelet identity on ACR scope (for your records):"
           az role assignment list --assignee-object-id "$PRINCIPAL_ID" --scope "$ACR_ID" -o table || true
 
-      - name: Ensure namespace exists
+      - name: Ensure namespace exists and set as current
         run: |
           kubectl create namespace shop --dry-run=client -o yaml | kubectl apply -f -
+          # Make 'shop' the default namespace for all following kubectl commands
+          kubectl config set-context --current --namespace=shop
 
       - name: Deploy Backend Infrastructure (Namespace, ConfigMaps, Secrets, Databases)
         run: |
-          echo "Deploying backend infrastructure..."
-          cd k8s/
-          kubectl apply -f configmaps.yaml
-          kubectl apply -f secrets.yaml
-          kubectl apply -f product-db.yaml
-          kubectl apply -f order-db.yaml
+          echo "Deploying backend infrastructure into namespace 'shop'..."
+          kubectl apply -n shop -f k8s/configmaps.yaml
+          kubectl apply -n shop -f k8s/secrets.yaml
+          kubectl apply -n shop -f k8s/product-db.yaml
+          kubectl apply -n shop -f k8s/order-db.yaml
 
       - name: Deploy Backend Microservices (Product, Order)
         run: |
-          echo "Deploying backend microservices..."
-          cd k8s/
-          kubectl apply -f product-service.yaml
-          kubectl apply -f order-service.yaml
+          echo "Deploying backend microservices into namespace 'shop'..."
+          kubectl apply -n shop -f k8s/product-service.yaml
+          kubectl apply -n shop -f k8s/order-service.yaml
+          echo "Listing resources in 'shop' for visibility:"
+          kubectl get all -n shop
+
+      - name: Detect service names (handles -w08e1 suffix or custom names)
+        id: detect_names
+        run: |
+          # Find the first service whose name contains "product" and "order"
+          PROD_SVC=$(kubectl get svc -n shop -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -m1 -E 'product')
+          ORDER_SVC=$(kubectl get svc -n shop -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -m1 -E 'order')
+
+          if [ -z "$PROD_SVC" ] || [ -z "$ORDER_SVC" ]; then
+            echo "Could not detect service names. Current services:"
+            kubectl get svc -n shop
+            exit 1
+          fi
+
+          echo "Detected Product service: $PROD_SVC"
+          echo "Detected Order service:   $ORDER_SVC"
+          echo "PROD_SVC=$PROD_SVC" >> $GITHUB_ENV
+          echo "ORDER_SVC=$ORDER_SVC" >> $GITHUB_ENV
 
       - name: Wait for Backend LoadBalancer IPs
         run: |
-          echo "Waiting for Product, Order LoadBalancer IPs to be assigned (up to 5 minutes)..."
+          echo "Waiting for LoadBalancer IPs to be assigned (up to 5 minutes)..."
           PRODUCT_IP=""
           ORDER_IP=""
 
           for i in $(seq 1 60); do
             echo "Attempt $i/60 to get IPs..."
-            PRODUCT_IP=$(kubectl get service product-service -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
-            ORDER_IP=$(kubectl get service order-service -o jsonpath='{.status.loadBalancer.ingress[0].ip}' || true)
+            PRODUCT_IP=$(kubectl get service "$PROD_SVC" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+            ORDER_IP=$(kubectl get service "$ORDER_SVC" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
 
             if [[ -n "$PRODUCT_IP" && -n "$ORDER_IP" ]]; then
               echo "All backend LoadBalancer IPs assigned!"
-              echo "Product Service IP: $PRODUCT_IP"
-              echo "Order Service IP: $ORDER_IP"
+              echo "Product Service ($PROD_SVC) IP: $PRODUCT_IP"
+              echo "Order Service   ($ORDER_SVC) IP: $ORDER_IP"
               break
             fi
             sleep 5
@@ -92,6 +111,8 @@ jobs:
 
           if [[ -z "$PRODUCT_IP" || -z "$ORDER_IP" ]]; then
             echo "Error: One or more LoadBalancer IPs not assigned after timeout."
+            echo "Current services in 'shop':"
+            kubectl get svc -n shop -o wide || true
             exit 1
           fi
 

--- a/.github/workflows/backend-cd.yml
+++ b/.github/workflows/backend-cd.yml
@@ -42,13 +42,6 @@ jobs:
             --name ${{ github.event.inputs.aks_cluster_name }} \
             --overwrite-existing
 
-      # We already granted AcrPull; just log the assignment for record-keeping
-      - name: Verify AcrPull role exists (non-blocking)
-        run: |
-          ACR_ID=$(az acr show -n ${{ github.event.inputs.aks_acr_name }} --query id -o tsv)
-          PRINCIPAL_ID=$(az aks show -g ${{ github.event.inputs.aks_resource_group }} -n ${{ github.event.inputs.aks_cluster_name }} --query identityProfile.kubeletidentity.objectId -o tsv)
-          az role assignment list --assignee-object-id "$PRINCIPAL_ID" --scope "$ACR_ID" -o table || true
-
       - name: Ensure namespace exists and set as current
         run: |
           kubectl create namespace shop --dry-run=client -o yaml | kubectl apply -f -
@@ -56,7 +49,6 @@ jobs:
 
       - name: Deploy Backend Infrastructure (Namespace, ConfigMaps, Secrets, Databases)
         run: |
-          echo "Deploying backend infrastructure into namespace 'shop'..."
           kubectl apply -n shop -f k8s/configmaps.yaml
           kubectl apply -n shop -f k8s/secrets.yaml
           kubectl apply -n shop -f k8s/product-db.yaml
@@ -64,72 +56,50 @@ jobs:
 
       - name: Deploy Backend Microservices (Product, Order)
         run: |
-          echo "Deploying backend microservices into namespace 'shop'..."
           kubectl apply -n shop -f k8s/product-service.yaml
           kubectl apply -n shop -f k8s/order-service.yaml
-          echo "Listing resources in 'shop' for visibility:"
           kubectl get all -n shop
 
-      - name: Detect service names (handles -w08e1 suffix or custom names)
-        id: detect_names
+      # ✅ Hardcode the correct LB service names you actually have
+      - name: Set service names explicitly
         run: |
-          # Find the first service whose name contains "product" and "order"
-          PROD_SVC=$(kubectl get svc -n shop -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -m1 -E 'product')
-          ORDER_SVC=$(kubectl get svc -n shop -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | grep -m1 -E 'order')
+          echo "PROD_SVC=product-service-w08e1"  >> $GITHUB_ENV
+          echo "ORDER_SVC=order-service-w08e1"   >> $GITHUB_ENV
 
-          if [ -z "$PROD_SVC" ] || [ -z "$ORDER_SVC" ]; then
-            echo "Could not detect service names. Current services:"
-            kubectl get svc -n shop
-            exit 1
-          fi
-
-          echo "Detected Product service: $PROD_SVC"
-          echo "Detected Order service:   $ORDER_SVC"
-          echo "PROD_SVC=$PROD_SVC" >> $GITHUB_ENV
-          echo "ORDER_SVC=$ORDER_SVC" >> $GITHUB_ENV
-
-      - name: Wait for Backend LoadBalancer IPs (robust)
+      # Short, robust fetch: accept ip or hostname; loop briefly just in case
+      - name: Fetch Backend LoadBalancer endpoints
         run: |
-          echo "Waiting for LoadBalancer endpoints (up to 12 minutes)..."
+          get_lb () {
+            local svc="$1"
+            local v
+            v=$(kubectl get svc "$svc" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+            if [ -z "$v" ]; then
+              v=$(kubectl get svc "$svc" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
+            fi
+            echo "$v"
+          }
+
           PRODUCT_IP=""
           ORDER_IP=""
 
-          # Helper to read IP or hostname
-          get_lb_endpoint () {
-            local svc="$1"
-            local val
-            val=$(kubectl get svc "$svc" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
-            if [ -z "$val" ]; then
-              val=$(kubectl get svc "$svc" -n shop -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true)
-            fi
-            echo "$val"
-          }
-
-          # Poll up to 140 times * 5s = ~11m40s
-          for i in $(seq 1 140); do
-            echo "Attempt $i/140 ..."
-            PRODUCT_IP=$(get_lb_endpoint "$PROD_SVC")
-            ORDER_IP=$(get_lb_endpoint "$ORDER_SVC")
-            printf "  %s => '%s'\n" "$PROD_SVC"  "${PRODUCT_IP:-<pending>}"
-            printf "  %s => '%s'\n" "$ORDER_SVC" "${ORDER_IP:-<pending>}"
-            if [[ -n "$PRODUCT_IP" && -n "$ORDER_IP" ]]; then
-              echo "LoadBalancer endpoints are ready."
-              break
-            fi
+          for i in $(seq 1 30); do  # ~2.5 minutes max; your IPs already exist
+            PRODUCT_IP=$(get_lb "$PROD_SVC")
+            ORDER_IP=$(get_lb "$ORDER_SVC")
+            echo "Attempt $i: $PROD_SVC => ${PRODUCT_IP:-<pending>}, $ORDER_SVC => ${ORDER_IP:-<pending>}"
+            if [[ -n "$PRODUCT_IP" && -n "$ORDER_IP" ]]; then break; fi
             sleep 5
           done
 
           if [[ -z "$PRODUCT_IP" || -z "$ORDER_IP" ]]; then
-            echo "Error: One or more LoadBalancer endpoints not ready after timeout."
-            echo "Current services in 'shop':"
+            echo "Services didn't report LB endpoints fast enough:"
             kubectl get svc -n shop -o wide || true
             exit 1
           fi
 
           echo "PRODUCT_IP=$PRODUCT_IP" >> $GITHUB_ENV
-          echo "ORDER_IP=$ORDER_IP" >> $GITHUB_ENV
-          echo "Resolved Product endpoint: $PRODUCT_IP"
-          echo "Resolved Order endpoint:   $ORDER_IP"
+          echo "ORDER_IP=$ORDER_IP"   >> $GITHUB_ENV
+          echo "Product endpoint: $PRODUCT_IP"
+          echo "Order endpoint:   $ORDER_IP"
 
       - name: Capture Product Service IP for Workflow Output
         id: get_product_ip

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -2,90 +2,71 @@
 
 name: Backend CI - Test, Build and Push Images to ACR
 
-# Trigger the workflow on pushes to the 'main' branch
-# You can also add 'pull_request:' to run on PRs
 on:
-  # Manual trigger
   workflow_dispatch:
-
-  # Automatically on pushes to main branch
   push:
-    branches:
-      - main
-    paths: # Only trigger if changes are in backend directories
+    branches: [ main ]
+    paths:
       - 'backend/**'
-      - '.github/workflows/backend_ci.yml' # Trigger if this workflow file changes
+      - '.github/workflows/backend_ci.yml'
 
-# Define global environment variables that can be used across jobs
+# Global env
 env:
-  # ACR Login Server (e.g., myregistry.azurecr.io)
-  # This needs to be set as a GitHub Repository Secret
-  ACR_LOGIN_SERVER: ${{ secrets.AZURE_CONTAINER_REGISTRY }}
-  # Dynamically generate image tags based on Git SHA and GitHub Run ID
-  # This provides unique, traceable tags for each image build
+  # Registry name (no domain, e.g. acrweek0820618)
+  ACR_NAME: ${{ secrets.ACR_NAME }}
+  # Registry login server (with domain, e.g. acrweek0820618.azurecr.io)
+  ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }}
   IMAGE_TAG: ${{ github.sha }}-${{ github.run_id }}
 
 jobs:
-  # Job 1: Run tests and linting for all backend services
   test_and_lint_backends:
-    runs-on: ubuntu-latest # Use a GitHub-hosted runner
+    runs-on: ubuntu-latest
 
     services:
-      # Product DB container
       product_db:
         image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: products
-        # Make pg_isready available so the service is healthy before tests run
         options: >-
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-        ports:
-          - 5432:5432
-      
-      # Order DB
+        ports: [ "5432:5432" ]
+
       order_db:
         image: postgres:15
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: orders
-        ports:
-          - 5433:5432
         options: >-
           --health-cmd "pg_isready -U postgres"
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports: [ "5433:5432" ]
 
     steps:
-      # 1. Checkout the repository code to the runner
       - name: Checkout repository
-        uses: actions/checkout@v4 # Action to check out your repository code
+        uses: actions/checkout@v4
 
-      # 2. Set up Python environment
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5 # Action to set up Python environment
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
-      # 3. Install dependencies and run code quality checks
       - name: Install dependencies
-        run: | # Use a multi-line script to install pip dependencies
+        run: |
           pip install --upgrade pip
-          # Loop through each backend service folder
           for req in backend/*/requirements.txt; do
             echo "Installing $req"
             pip install -r "$req"
           done
-          # Install CI tools
           pip install pytest httpx
 
-      # 5. Run tests for product service
       - name: Run product_service tests
         working-directory: backend/product_service
         env:
@@ -94,10 +75,8 @@ jobs:
           POSTGRES_DB: products
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        run: |
-          pytest tests --maxfail=1 --disable-warnings -q
-      
-      # 6. Run tests for order service
+        run: pytest tests --maxfail=1 --disable-warnings -q
+
       - name: Run order_service tests
         working-directory: backend/order_service
         env:
@@ -106,41 +85,36 @@ jobs:
           POSTGRES_DB: orders
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-        run: |
-          pytest tests --maxfail=1 --disable-warnings -q
+        run: pytest tests --maxfail=1 --disable-warnings -q
 
-  # Job 2: Build and Push Docker Images (runs only if tests pass)
   build_and_push_images:
     runs-on: ubuntu-latest
     needs: test_and_lint_backends
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Azure login using a Service Principal secret
-    - name: Azure Login
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }} # Needs to be set as a GitHub Secret (Service Principal JSON)
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    # Login to Azure Container Registry (ACR)
-    - name: Login to Azure Container Registry
-      run: az acr login --name ${{ env.ACR_LOGIN_SERVER }}
+      # ✅ Use the registry NAME with --name
+      - name: Login to Azure Container Registry
+        run: az acr login --name ${{ env.ACR_NAME }}
 
-    # Build and Push Docker image for Product Service
-    - name: Build and Push Product Service Image
-      run: |
-        docker build -t ${{ env.ACR_LOGIN_SERVER }}/product_service:latest ./backend/product_service/
-        docker push ${{ env.ACR_LOGIN_SERVER }}/product_service:latest
+      # ✅ Use the LOGIN SERVER for image tags/push
+      - name: Build and Push Product Service Image
+        run: |
+          docker build -t ${{ env.ACR_LOGIN_SERVER }}/product_service:latest ./backend/product_service/
+          docker push ${{ env.ACR_LOGIN_SERVER }}/product_service:latest
 
-    # Build and Push Docker image for Order Service
-    - name: Build and Push Order Service Image
-      run: |
-        docker build -t ${{ env.ACR_LOGIN_SERVER }}/order_service:latest ./backend/order_service/
-        docker push ${{ env.ACR_LOGIN_SERVER }}/order_service:latest
+      - name: Build and Push Order Service Image
+        run: |
+          docker build -t ${{ env.ACR_LOGIN_SERVER }}/order_service:latest ./backend/order_service/
+          docker push ${{ env.ACR_LOGIN_SERVER }}/order_service:latest
 
-    # Logout from Azure for security (runs even if image push fails)
-    - name: Logout from Azure
-      run: az logout
-      if: always()
+      - name: Logout from Azure
+        if: always()
+        run: az logout

--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -1,53 +1,41 @@
-# week08/.github/workflows/frontend_ci.yml
-
 name: Frontend CI - Build & Push Image
 
 on:
-  # Manual trigger
   workflow_dispatch:
-
-  # Automatically on pushes to main branch
   push:
-    branches:
-      - main
-    paths: # Only trigger if changes are in the frontend directory
+    branches: [ main ]
+    paths:
       - 'frontend/**'
-      - '.github/workflows/frontend_ci.yml' # Trigger if this workflow file changes
-
-# Define global environment variables that can be used across jobs
-env:
-  # ACR Login Server (e.g., myregistry.azurecr.io)
-  # This needs to be set as a GitHub Repository Secret
-  ACR_LOGIN_SERVER: ${{ secrets.AZURE_CONTAINER_REGISTRY }}
-  # Dynamically generate image tags based on Git SHA and GitHub Run ID
-  # This provides unique, traceable tags for each image build
-  IMAGE_TAG: ${{ github.sha }}-${{ github.run_id }}
+      - '.github/workflows/frontend-ci.yml'
 
 jobs:
-  build_and_push_frontend:
+  build_and_push_image:
     runs-on: ubuntu-latest
 
+    env:
+      # must exist in your repo secrets
+      ACR_NAME: ${{ secrets.ACR_NAME }}                 # e.g. acrweek0820618
+      ACR_LOGIN_SERVER: ${{ secrets.ACR_LOGIN_SERVER }} # e.g. acrweek0820618.azurecr.io
+
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout
+      # fetch the code
+        uses: actions/checkout@v4
 
-    # Azure login using a Service Principal secret
-    - name: Azure Login
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Azure Login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
 
-    # Login to Azure Container Registry (ACR)
-    - name: Login to Azure Container Registry
-      run: az acr login --name ${{ env.ACR_LOGIN_SERVER }}
+      - name: ACR Login
+        run: az acr login --name "${{ env.ACR_NAME }}"
 
-    # Build and Push Docker image for Frontend
-    - name: Build and Push Frontend Image
-      run: |
-        docker build -t ${{ env.ACR_LOGIN_SERVER }}/frontend:latest ./frontend/
-        docker push ${{ env.ACR_LOGIN_SERVER }}/frontend:latest
+      # Adjust path if your Dockerfile is not in ./frontend
+      - name: Docker Build & Push
+        run: |
+          docker build -t "${{ env.ACR_LOGIN_SERVER }}/frontend:latest" ./frontend
+          docker push "${{ env.ACR_LOGIN_SERVER }}/frontend:latest"
 
-    # Logout from Azure for security (runs even if image push fails)
-    - name: Logout from Azure
-      run: az logout
-      if: always()
+      - name: Azure Logout
+        if: always()
+        run: az logout

--- a/k8s/frontend-config.yaml
+++ b/k8s/frontend-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: frontend-config
+  namespace: shop
+data:
+  PRODUCT_API_URL: "http://20.227.82.107:8000"
+  ORDER_API_URL: "http://20.53.162.214:8001"

--- a/k8s/frontend.yaml
+++ b/k8s/frontend.yaml
@@ -1,11 +1,8 @@
-# week08/k8s/frontend.yaml
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: frontend
-  labels:
-    app: frontend
+  name: frontend-w08e1
+  namespace: shop
 spec:
   replicas: 1
   selector:
@@ -17,23 +14,26 @@ spec:
         app: frontend
     spec:
       containers:
-      - name: frontend-container
-        image: durgeshsamariya.azurecr.io/frontend:latest
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 80
+        - name: frontend
+          # use your ACR image
+          image: acrweek0820618.azurecr.io/frontend:latest
+          ports:
+            - containerPort: 80
+          # read backend URLs from the ConfigMap you just made
+          envFrom:
+            - configMapRef:
+                name: frontend-config
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: frontend-w08e1 # Service name matches
-  labels:
-    app: frontend
+  name: frontend-service-w08e1
+  namespace: shop
 spec:
+  type: LoadBalancer
   selector:
     app: frontend
   ports:
-    - protocol: TCP
-      port: 80 # The port the service listens on inside the cluster
-      targetPort: 80 # The port on the Pod (containerPort where Nginx runs)
-  type: LoadBalancer # Exposes the service on a port on each Node's IP
+    - name: http
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
Summary
- Added reusable workflow: .github/workflows/reusable-acr-build.yml
- Updated backend_ci.yml and frontend_ci.yml to call the reusable build job.
- Standardized image tagging and ACR login usage.
- Prepares the repo to later link CI → CD with a single image_ref output.

Why this is better
- DRY: one place to maintain ACR login/build/push.
- Consistent tags and faster builds (Buildx + cache ready).
- Clear separation of concerns: services define only image name + context.

How to verify
- Run “Backend CI” or “Frontend CI” on a branch; both now call the reusable job.
- Check the job output `image_ref` and the pushed image in ACR (when secrets are present).

Follow-up (separate PR)
- Update CD workflows to consume `image_ref` from CI and deploy pinned images.
